### PR TITLE
Configurable SSL client method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ followed with *myftp.Login("myuser","mypass")* and ended by *myftp.Quit()*. For 
 methods documentation. Most methods have their tasks pretty much explained in their name. ftplibpp uses OpenSSL for 
 encryption functionality, if you don't need it you can set the "NOSSL" flag (e.g. g++ -c ftplib.cpp -DNOSSL ). If your 
 system does not feature large file support (or does not need specific LFS functions, because it's built in yet) you can 
-use the "NOLFS" flag (e.g. g++ -c ftplib.cpp -DNOLFS ).
+use the "NOLFS" flag (e.g. g++ -c ftplib.cpp -DNOLFS ). The flag _FTPLIB_SSL_CLIENT_METHOD_ exists to override the 
+openssl client method in use, the default is "TLSv1_2_client_method", override by compiling with -D_FTPLIB_SSL_CLIENT_METHOD_=<method>
+no paranthesis are required.
 
 ### Public types
 

--- a/ftplib.cpp
+++ b/ftplib.cpp
@@ -110,7 +110,7 @@ ftplib::ftplib()
 		free(mp_ftphandle);
 	}
 	#ifndef NOSSL
-	mp_ftphandle->ctx = SSL_CTX_new(SSLv3_method());
+	mp_ftphandle->ctx = SSL_CTX_new(_FTPLIB_SSL_CLIENT_METHOD_());
 	SSL_CTX_set_verify(mp_ftphandle->ctx, SSL_VERIFY_NONE, NULL);
 	mp_ftphandle->ssl = SSL_new(mp_ftphandle->ctx);
 	#endif
@@ -1198,7 +1198,7 @@ int ftplib::FtpXfer(const char *localfile, const char *path, ftphandle *nControl
 
 	if (localfile != NULL)
 	{
-		printf("localfile: -%s-", localfile);
+		// printf("localfile: -%s-", localfile);
 	
 		//local = fopen(localfile, (typ == ftplib::filewrite) ? "r" : "w");
 		char ac[3] = "  ";
@@ -1252,10 +1252,8 @@ int ftplib::FtpXfer(const char *localfile, const char *path, ftphandle *nControl
 	}
 	free(dbuf);
 	fflush(local);
-	if (localfile != NULL)
-	fclose(local);
+	if (localfile != NULL) fclose(local);
 	return FtpClose(nData);
-	return rv;
 }
 
 /*

--- a/ftplib.h
+++ b/ftplib.h
@@ -56,7 +56,7 @@
 #endif
 
 #ifndef _FTPLIB_SSL_CLIENT_METHOD_
-#define _FTPLIB_SSL_CLIENT_METHOD_ SSLv3_method
+#define _FTPLIB_SSL_CLIENT_METHOD_ TLSv1_2_client_method
 #endif//_FTPLIB_SSL_CLIENT_METHOD_
 
 using namespace std;

--- a/ftplib.h
+++ b/ftplib.h
@@ -55,6 +55,10 @@
 #include <openssl/ssl.h>
 #endif
 
+#ifndef _FTPLIB_SSL_CLIENT_METHOD_
+#define _FTPLIB_SSL_CLIENT_METHOD_ SSLv3_method
+#endif//_FTPLIB_SSL_CLIENT_METHOD_
+
 using namespace std;
 
 /**


### PR DESCRIPTION
Allows people to use TLS1.2 if they wish

Use with "-D_FTPLIB_SSL_CLIENT_METHOD_=TLSv1_2_client_method"

