### PR TITLE
Fixed undeclared variable ret error without NOSSL.

### DIFF
--- a/ftplib.cpp
+++ b/ftplib.cpp
@@ -702,8 +702,7 @@ int ftplib::FtpAccess(const char *path, accesstype type, transfermode mode, ftph
 		(*nData)->ssl = SSL_new(nControl->ctx);
 		(*nData)->sbio = BIO_new_socket((*nData)->handle, BIO_NOCLOSE);
 		SSL_set_bio((*nData)->ssl,(*nData)->sbio,(*nData)->sbio);
-		ret = SSL_connect((*nData)->ssl);
-		if (ret != 1) return 0;
+		if (SSL_connect((*nData)->ssl) != 1) return 0;
 		(*nData)->tlsdata = 1;
 	}
 #endif


### PR DESCRIPTION
Hi,
I'm currently using ftplibpp to access IIS FTPS server using SSL/TLS encryption.
It works great but I had one problem building it without -DNOSSL.

This problem was introduced in 6e7cd454e067f6efb288ea64c9720a1a7c5b3c99 where the declaration of 'ret' was removed from ftplib::FtpAccess.

This patch fixes the problem.

Cheers, 
Ronny